### PR TITLE
fix article translation

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItem.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItem.php
@@ -140,6 +140,28 @@ class PlentymarketsImportEntityItem
 				$swItemID = PlentymarketsMappingController::getItemByPlentyID($this->ItemBase->ItemID);
 
 				PlentymarketsTranslation::setShopwareTranslation('article', $swItemID, $itemText['languageShopId'], $swItemText);
+				
+				// save the translation in s_articles_translations, too
+				$sql = '
+                		INSERT INTO `s_articles_translations` (
+		                  articleID, languageID, name, keywords, description, description_long
+		                ) VALUES (
+		                  ?, ?, ?, ?, ?, ?
+		                ) ON DUPLICATE KEY UPDATE
+		                  name = VALUES(name),
+		                  keywords = VALUES(keywords),
+		                  description = VALUES(description),
+		                  description_long = VALUES(description_long);
+		            	';
+				
+				Shopware()->Db()->query($sql, array(
+					$swItemID,
+					$itemText['languageShopId'],
+					isset($swItemText['txtArtikel']) ? (string) $swItemText['txtArtikel'] : '',
+					($swItemText['txtkeywords']) ? (string) $swItemText['txtkeywords'] : '',
+					isset($swItemText['txtshortdescription']) ? (string) $swItemText['txtshortdescription'] : '',
+					isset($swItemText['txtlangbeschreibung']) ? (string) $swItemText['txtlangbeschreibung'] : ''
+				));
 			}
 		}
 	}


### PR DESCRIPTION
The translations of an article must be saved in the database table 's_articles_translations'. This entries are in use for the seo logic.