### PR TITLE
changed the product number regex for Shopware > 5.0.2

### DIFF
--- a/Components/Import/PlentymarketsImportItemHelper.php
+++ b/Components/Import/PlentymarketsImportItemHelper.php
@@ -166,10 +166,18 @@ class PlentymarketsImportItemHelper
 		{
 			return false;
 		}
-		if (preg_match('/[^a-zA-Z0-9\.\-_ \/]/', $number))
+
+		if (version_compare(Shopware::VERSION, '5.0.2', '>=')) {
+			$regex = '/[^a-zA-Z0-9\.\-_\/]/';
+		} else {
+			$regex = '/[^a-zA-Z0-9\.\-_ \/]/';
+		}
+
+		if (preg_match($regex, $number))
 		{
 			return false;
 		}
+
 		return true;
 	}
 }

--- a/Components/Import/PlentymarketsImportItemHelper.php
+++ b/Components/Import/PlentymarketsImportItemHelper.php
@@ -168,7 +168,7 @@ class PlentymarketsImportItemHelper
 		}
 
 		if (version_compare(Shopware::VERSION, '5.0.2', '>=')) {
-			$regex = '/[^a-zA-Z0-9-_.]/';
+			$regex = '/[^a-zA-Z0-9\-\_\.]/';
 		} else {
 			$regex = '/[^a-zA-Z0-9\.\-_ \/]/';
 		}

--- a/Components/Import/PlentymarketsImportItemHelper.php
+++ b/Components/Import/PlentymarketsImportItemHelper.php
@@ -168,7 +168,7 @@ class PlentymarketsImportItemHelper
 		}
 
 		if (version_compare(Shopware::VERSION, '5.0.2', '>=')) {
-			$regex = '/[^a-zA-Z0-9\.\-_\/]/';
+			$regex = '/[^a-zA-Z0-9-_.]/';
 		} else {
 			$regex = '/[^a-zA-Z0-9\.\-_ \/]/';
 		}


### PR DESCRIPTION
Shopware has changed the allowed product number regex in 5.0.2, attached a small pr to change the regex when Shopware is running in that version or newer. 

From their upgrade.md:
"It's no longer possible to have spaces in article numbers. Existing articles with spaces in their numbers will still work, but the article cannot be changed without fixing the number."