### PR TITLE
thumbnails are generated twice on Shopware > 4.2

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
@@ -257,7 +257,7 @@ class PlentymarketsImportEntityItemImage
 					$image->setPosition($Image->Position);
 
 					// Generate the thumbnails
-					if (version_compare('4.2', Shopware::VERSION) != 1)
+					if (version_compare(Shopware::VERSION, '4.2') != 1)
 					{
 						PlentymarketsImportItemImageThumbnailController::getInstance()->addMediaResource($media);
 					}


### PR DESCRIPTION
Small Bugfix from one of our customer forks, the thumbnails are generated automatically when saving the model. The version_compare was switched to only when the Shopware version is lower then 4.2, the old generation method is used.