### PR TITLE
item import - setting the additionaltext for a variant

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItem.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItem.php
@@ -451,7 +451,11 @@ class PlentymarketsImportEntityItem
 				$details['shippingtime'] = $shippingTime;
 			}
 
-			$details['additionaltext'] = $AttributeValueSet->AttributeValueSetName;
+			if(version_compare(Shopware::VERSION, '4.3.6', '<='))
+			{
+				$details['additionaltext'] = $AttributeValueSet->AttributeValueSetName;
+			}
+			
 			$details['ean'] = $AttributeValueSet->EAN;
 			$details['X_plentySku'] = $sku;
 

--- a/Components/Import/Entity/PlentymarketsImportEntityItem.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItem.php
@@ -451,7 +451,7 @@ class PlentymarketsImportEntityItem
 				$details['shippingtime'] = $shippingTime;
 			}
 
-			if(version_compare(Shopware::VERSION, '4.3.6', '<='))
+			if(version_compare(Shopware::VERSION, '5.0.0', '<'))
 			{
 				$details['additionaltext'] = $AttributeValueSet->AttributeValueSetName;
 			}


### PR DESCRIPTION
to set the addtionaltext for a variant is deprecated since shopware version >= 5.0.0