### PR TITLE
delete all variant image mappings of an item

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
@@ -99,6 +99,15 @@ class PlentymarketsImportEntityItemImage
 				PyLog()->error('Sync:Item:Image', 'The media resource with the id »' . $image['mediaId'] . '« of the item image »' . $image['description'] . '« could not be deleted (' . $E->getMessage() . ')');
 			}
 		}
+		
+		// Delete all variant image mappings of the item		
+		// Add the main detail
+		$article['details'][] = $article['mainDetail'];
+		
+		foreach($article['details'] as $detail)
+		{
+			Shopware()->Db()->query("DELETE FROM `s_articles_img` WHERE article_detail_id = ?", array($detail['id']));
+		}
 
 		$ArticleResource->update($this->SHOPWARE_itemId, array(
 			'images' => array()
@@ -298,18 +307,6 @@ class PlentymarketsImportEntityItemImage
 		$mainImage->setMain(1);
 		Shopware()->Models()->persist($mainImage);
 		Shopware()->Models()->flush();
-		
-		// Delete all variant image mappings of the item
-		$ArticleResource = \Shopware\Components\Api\Manager::getResource('Article');
-		$article = $ArticleResource->getOne($this->SHOPWARE_itemId);
-		
-		// Add the main detail
-		$article['details'][] = $article['mainDetail'];
-		
-		foreach($article['details'] as $detail)
-		{
-			Shopware()->Db()->query("DELETE FROM `s_articles_img` WHERE article_detail_id = ?", array($detail['id']));
-		}
 
 		// Get the variant images
 		$Request_GetItemsVariantImages = new PlentySoapRequest_GetItemsVariantImages();

--- a/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
@@ -298,6 +298,15 @@ class PlentymarketsImportEntityItemImage
 		$mainImage->setMain(1);
 		Shopware()->Models()->persist($mainImage);
 		Shopware()->Models()->flush();
+		
+		// Delete all variant image mappings of the item
+		$ArticleResource = \Shopware\Components\Api\Manager::getResource('Article');
+		$article = $ArticleResource->getOne($this->SHOPWARE_itemId);
+		
+		foreach($article['details'] as $detail)
+		{
+			Shopware()->Db()->query("DELETE FROM `s_articles_img` WHERE article_detail_id = ?", array($detail['id']));
+		}
 
 		// Get the variant images
 		$Request_GetItemsVariantImages = new PlentySoapRequest_GetItemsVariantImages();

--- a/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItemImage.php
@@ -303,6 +303,9 @@ class PlentymarketsImportEntityItemImage
 		$ArticleResource = \Shopware\Components\Api\Manager::getResource('Article');
 		$article = $ArticleResource->getOne($this->SHOPWARE_itemId);
 		
+		// Add the main detail
+		$article['details'][] = $article['mainDetail'];
+		
 		foreach($article['details'] as $detail)
 		{
 			Shopware()->Db()->query("DELETE FROM `s_articles_img` WHERE article_detail_id = ?", array($detail['id']));


### PR DESCRIPTION
If the exists variant image mappings are not deleted before fetching the current variant image mappings from plenty, the exists mappings in the sw db multiplicated with each item image update.