### PR TITLE
Adds objectType to removeIdentity and fixes wrong adapter name

### DIFF
--- a/Adapter/PlentymarketsAdapter/QueryBus/QueryHandler/Manufacturer/FetchManufacturerQueryHandler.php
+++ b/Adapter/PlentymarketsAdapter/QueryBus/QueryHandler/Manufacturer/FetchManufacturerQueryHandler.php
@@ -14,7 +14,6 @@ use PlentymarketsAdapter\Client\Exception\InvalidCredentialsException;
 use PlentymarketsAdapter\PlentymarketsAdapter;
 use PlentymarketsAdapter\ResponseParser\ResponseParserInterface;
 use Psr\Log\LoggerInterface;
-use ShopwareAdapter\ShopwareAdapter;
 use UnexpectedValueException;
 
 /**
@@ -87,7 +86,7 @@ class FetchManufacturerQueryHandler implements QueryHandlerInterface
         $identity = $this->identityService->findIdentity([
             'objectIdentifier' => $event->getIdentifier(),
             'objectType' => Manufacturer::getType(),
-            'adapterName' => ShopwareAdapter::getName(),
+            'adapterName' => PlentymarketsAdapter::getName(),
         ]);
 
         $element = $this->client->request('GET', 'items/manufacturers/' . $identity->getAdapterIdentifier());

--- a/Connector/IdentityService/IdentityService.php
+++ b/Connector/IdentityService/IdentityService.php
@@ -99,12 +99,14 @@ class IdentityService implements IdentityServiceInterface
     /**
      * @param $adapterIdentifier
      * @param $adapterName
+     * @param $objectType
      */
-    public function removeIdentity($adapterIdentifier, $adapterName)
+    public function removeIdentity($adapterIdentifier, $adapterName, $objectType)
     {
         Assertion::string($adapterIdentifier);
         Assertion::string($adapterName);
+        Assertion::string($objectType);
 
-        $this->storage->remove($adapterIdentifier, $adapterName);
+        $this->storage->remove($adapterIdentifier, $adapterName, $objectType);
     }
 }

--- a/Connector/IdentityService/Storage/DoctrineIdentityStorage.php
+++ b/Connector/IdentityService/Storage/DoctrineIdentityStorage.php
@@ -79,11 +79,12 @@ class DoctrineIdentityStorage implements IdentityStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function remove($adapterIdentifier, $adapterName)
+    public function remove($adapterIdentifier, $adapterName, $objectType)
     {
         $result = $this->identityRepository->findBy([
             'adapterIdentifier' => $adapterIdentifier,
             'adapterName' => $adapterName,
+            'objectType' => $objectType,
         ]);
 
         foreach ($result as $identity) {

--- a/Connector/IdentityService/Storage/IdentityStorageInterface.php
+++ b/Connector/IdentityService/Storage/IdentityStorageInterface.php
@@ -24,6 +24,7 @@ interface IdentityStorageInterface
     /**
      * @param $adapterIdentifier
      * @param $adapterName
+     * @param $objectType
      */
-    public function remove($adapterIdentifier, $adapterName);
+    public function remove($adapterIdentifier, $adapterName, $objectType);
 }


### PR DESCRIPTION
The objectType is necessary to uniquely identify identities since it is not guaranteed that adapterIdentifier is unique across different types.