### PR TITLE
add event PlentyConnector_ImportEntityItemPrice_BeforeSavePrice

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItem.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItem.php
@@ -1021,8 +1021,22 @@ class PlentymarketsImportEntityItem
                         $VariantController->getMarkupByVariantId($variantId),
                         $VariantController->getReferencePriceByVaraintId($variantId)
 					);
+					
+					$prices = $PlentymarketsImportEntityItemPrice->getPrices();
+					
+					// BOF - Allow plugins to change the data before saving
+					$prices = Enlight()->Events()->filter(
+						'PlentyConnector_ImportEntityItemPrice_BeforeSavePrice',
+						$prices,
+						array(
+							'subject' => $this,
+							'number' => $variant['number'],
+							'ean' => $variant['ean']
+						)
+					);
+					// EOF - Allow plugins to change the data before saving
 
-					$variant['prices'] = $PlentymarketsImportEntityItemPrice->getPrices();
+					$variant['prices'] = $prices;					
                     $variant['purchasePrice'] = $VariantController->getPurchasePriceByVariantId($variantId);
 
                     // use purchase price from main product instead
@@ -1282,7 +1296,21 @@ class PlentymarketsImportEntityItem
                         $VariantController->getReferencePriceByVaraintId($variantId)
                     );
 
-                    $variant['prices'] = $PlentymarketsImportEntityItemPrice->getPrices();
+                    $prices = $PlentymarketsImportEntityItemPrice->getPrices();
+					
+					// BOF - Allow plugins to change the data before saving
+					$prices = Enlight()->Events()->filter(
+						'PlentyConnector_ImportEntityItemPrice_BeforeSavePrice',
+						$prices,
+						array(
+							'subject' => $this,
+							'number' => $variant['number'],
+							'ean' => $variant['ean']
+						)
+					);
+					// EOF - Allow plugins to change the data before saving
+
+					$variant['prices'] = $prices;
                     $variant['purchasePrice'] = $VariantController->getPurchasePriceByVariantId($variantId);
 
                     // use purchase price from main product instead


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT


#### What's in this PR?

This commit add the event PlentyConnector_ImportEntityItemPrice_BeforeSavePrice directly to the item import, because this event is only triggered, if the price was saved over the import entity item price.

#### Why?

(see above)

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
