### PR TITLE
change method setVariants

### DIFF
--- a/Components/Import/Entity/PlentymarketsImportEntityItem.php
+++ b/Components/Import/Entity/PlentymarketsImportEntityItem.php
@@ -477,12 +477,11 @@ class PlentymarketsImportEntityItem
 							throw new PlentymarketsImportItemNumberException('The item variation number »' . $number . '« of item »' . $this->data['name'] . '« with the id »' . $this->ItemBase->ItemID . '« would be assigned twice', 3112);
 						}
 
-						// Use this number
-						$details['number'] = $number;
-
 						// Cache the number
 						$numbersUsed[$number] = true;
 					}
+				} else {
+					$number = Shopware()->Db()->fetchOne('SELECT ordernumber FROM s_articles_details WHERE id = ?', array($details['id']));
 				}
 			}
 			catch (PlentymarketsMappingExceptionNotExistant $e)
@@ -508,17 +507,11 @@ class PlentymarketsImportEntityItem
 						throw new PlentymarketsImportItemNumberException('The item variation number »' . $number . '« of item »' . $this->data['name'] . '« with the id »' . $this->ItemBase->ItemID . '« would be assigned twice', 3112);
 					}
 
-					// Use this number
-					$details['number'] = $number;
-
 					// Cache the number
 					$numbersUsed[$number] = true;
-				}
-
-				else
-				{
+				} else {
 					// A new number is generated
-					$details['number'] = PlentymarketsImportItemHelper::getItemNumber();
+					$number = PlentymarketsImportItemHelper::getItemNumber();
 				}
 			}
 
@@ -533,6 +526,7 @@ class PlentymarketsImportEntityItem
 				$details['additionaltext'] = $AttributeValueSet->AttributeValueSetName;
 			}
 
+			$details['number'] = $number;
 			$details['ean'] = $AttributeValueSet->EAN;
 			$details['X_plentySku'] = $sku;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT


#### What's in this PR?

This commit change the method setVariants to set always the number of the detail, to use it on other events.
Before, the detail number is only set, if the detail was not created.

#### Why?
For example, the event PlentyConnector_ImportEntityItemPrice_BeforeSavePrice need the detail number.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
