### PR TITLE
ReadApi\Item: Retrieve all items

### DIFF
--- a/Adapter/PlentymarketsAdapter/ReadApi/Item.php
+++ b/Adapter/PlentymarketsAdapter/ReadApi/Item.php
@@ -19,18 +19,18 @@ class Item extends ApiAbstract
     {
         $languageHelper = new LanguageHelper();
 
-        return $this->client->request('GET', 'items', [
+        return iterator_to_array($this->client->getIterator('items', [
             'lang' => $languageHelper->getLanguagesQueryString(),
-        ]);
+        ]));
     }
 
     public function findChanged($startTimestamp, $endTimestamp)
     {
         $languageHelper = new LanguageHelper();
 
-        return $this->client->request('GET', 'items', [
+        return iterator_to_array($this->client->getIterator('items', [
             'lang' => $languageHelper->getLanguagesQueryString(),
             'updatedBetween' => $startTimestamp . ',' . $endTimestamp,
-        ]);
+        ]));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #80
| License         | MIT


#### What's in this PR?

Use the `client->getIterator` method to retrieve all items, not only the first 50 items (first page).


#### Why?

During the synchronization, only the first 50 articles have been synced.


#### To Do

I did a search and it appears that besides the manufactures and now the articles/items, no requests makes use of `client->getIterator`. This will probably lead to problems, if there are more entities of one kind (e.g. categories).