### PR TITLE
REST requests: Pass (itemsPer)Page params

### DIFF
--- a/Adapter/PlentymarketsAdapter/Client/Client.php
+++ b/Adapter/PlentymarketsAdapter/Client/Client.php
@@ -308,6 +308,14 @@ class Client implements ClientInterface
 
         $requestOptions = [];
 
+        if (array_key_exists('itemsPerPage', $options)) {
+            $params['itemsPerPage'] = $options['itemsPerPage'];
+        }
+
+        if (array_key_exists('page', $options)) {
+            $params['page'] = $options['page'];
+        }
+
         if ($method === 'GET') {
             $requestOptions['query'] = $params;
         } else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #80
| License         | MIT


#### What's in this PR?

Pass `itemsPerPage`and `page` to REST requests.

#### Why?

The parameters page and itemsPerPage have been correctly calculated. However, the parameters were not passed to REST request, causing always only the first page to be returned for large responses.