### PR TITLE
Add mapping check

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Category/CategoryResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Category/CategoryResponseParser.php
@@ -113,6 +113,16 @@ class CategoryResponseParser implements CategoryResponseParserInterface
                 continue;
             }
 
+            $isMappedIdentity = $this->identityService->isMapppedIdentity(
+                $identity->getObjectIdentifier(),
+                $identity->getObjectType(),
+                $identity->getAdapterName()
+            );
+
+            if (!$isMappedIdentity) {
+                continue;
+            }
+
             $shopIdentifiers[] = $identity->getObjectIdentifier();
         }
 

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Order/OrderResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Order/OrderResponseParser.php
@@ -105,6 +105,16 @@ class OrderResponseParser implements OrderResponseParserInterface
             return [];
         }
 
+        $isMappedIdentity = $this->identityService->isMapppedIdentity(
+            $shopIdentity->getObjectIdentifier(),
+            $shopIdentity->getObjectType(),
+            $shopIdentity->getAdapterName()
+        );
+
+        if (!$isMappedIdentity) {
+            return [];
+        }
+
         $identity = $this->identityService->findOneOrCreate(
             (string) $entry['id'],
             PlentymarketsAdapter::NAME,

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -1030,6 +1030,16 @@ class ProductResponseParser implements ProductResponseParserInterface
                 continue;
             }
 
+            $isMappedIdentity = $this->identityService->isMapppedIdentity(
+                $identity->getObjectIdentifier(),
+                $identity->getObjectType(),
+                $identity->getAdapterName()
+            );
+
+            if (!$isMappedIdentity) {
+                continue;
+            }
+
             $identifiers[] = $identity->getObjectIdentifier();
         }
 

--- a/Adapter/ShopwareAdapter/ResponseParser/Payment/PaymentResponseParser.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/Payment/PaymentResponseParser.php
@@ -52,8 +52,25 @@ class PaymentResponseParser implements PaymentResponseParserInterface
             return [];
         }
 
+        $shopIdentity = $this->identityService->findOneOrThrow(
+            (string) $element['shopId'],
+            ShopwareAdapter::NAME,
+            Shop::TYPE
+        );
+
+        $isMappedIdentity = $this->identityService->isMapppedIdentity(
+            $shopIdentity->getObjectIdentifier(),
+            $shopIdentity->getObjectType(),
+            $shopIdentity->getAdapterName()
+        );
+
+        if (!$isMappedIdentity) {
+            return [];
+        }
+
         $payment = new Payment();
         $payment->setIdentifier($paymentIdentifier);
+        $payment->setShopIdentifier($shopIdentity->getObjectIdentifier());
         $payment->setOrderIdentifer($this->getIdentifier($element['id'], Order::TYPE));
         $payment->setAmount($element['invoiceAmount']);
         $payment->setCurrencyIdentifier($this->getIdentifier($this->getCurrencyId($element['currency']), Currency::TYPE));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - optimized the item cross selling retrieving
 - categories with no active shop assignment will be deactivated
 - order item vatRate is now synced correctly
+- added a isMapppedIdentity function to the identityService
+- implemented the isMapppedIdentity in all parsers to reduce the amount of objects transferred
 
 ### Fixed
 - product translations

--- a/Connector/IdentityService/IdentityService.php
+++ b/Connector/IdentityService/IdentityService.php
@@ -57,7 +57,8 @@ class IdentityService implements IdentityServiceInterface
         ]);
 
         if (null === $identity) {
-            throw new NotFoundException(sprintf('Could not find identity for %s with identifier %s in %s.', $objectType, $adapterIdentifier, $adapterName));
+            throw new NotFoundException(sprintf('Could not find identity for %s with identifier %s in %s.', $objectType,
+                $adapterIdentifier, $adapterName));
         }
 
         $this->validator->validate($identity);
@@ -168,5 +169,30 @@ class IdentityService implements IdentityServiceInterface
         $identity = $this->findOneBy($criteria);
 
         return (bool) $identity;
+    }
+
+    /**
+     * @param $objectIdentifier
+     * @param $objectType
+     * @param $adapterName
+     *
+     * @return bool
+     */
+    public function isMapppedIdentity($objectIdentifier, $objectType, $adapterName)
+    {
+        $identities = $this->findBy([
+            'objectIdentifier' => $objectIdentifier,
+            'objectType' => $objectType,
+        ]);
+
+        $otherIdentities = array_filter($identities, function (Identity $identity) use ($adapterName) {
+            return $identity->getAdapterName() !== $adapterName;
+        });
+
+        if (empty($otherIdentities)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Connector/IdentityService/IdentityServiceInterface.php
+++ b/Connector/IdentityService/IdentityServiceInterface.php
@@ -65,4 +65,13 @@ interface IdentityServiceInterface
      * @return bool
      */
     public function exists(array $criteria = []);
+
+    /**
+     * @param $objectIdentifier
+     * @param $objectType
+     * @param $adapterName
+     *
+     * @return bool
+     */
+    public function isMapppedIdentity($objectIdentifier, $objectType, $adapterName);
 }

--- a/Connector/TransferObject/Payment/Payment.php
+++ b/Connector/TransferObject/Payment/Payment.php
@@ -31,6 +31,11 @@ class Payment extends AbstractTransferObject
     /**
      * @var string
      */
+    private $shopIdentifier = '';
+
+    /**
+     * @var string
+     */
     private $currencyIdentifier = '';
 
     /**
@@ -111,6 +116,22 @@ class Payment extends AbstractTransferObject
     public function setAmount($amount)
     {
         $this->amount = $amount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getShopIdentifier()
+    {
+        return $this->shopIdentifier;
+    }
+
+    /**
+     * @param string $shopIdentifier
+     */
+    public function setShopIdentifier($shopIdentifier)
+    {
+        $this->shopIdentifier = $shopIdentifier;
     }
 
     /**

--- a/Connector/Validator/Order/Payment/PaymentValidator.php
+++ b/Connector/Validator/Order/Payment/PaymentValidator.php
@@ -26,6 +26,7 @@ class PaymentValidator implements ValidatorInterface
     public function validate($object)
     {
         Assertion::float($object->getAmount(), null, 'order.payment.amount');
+        Assertion::uuid($object->getShopIdentifier(), null, 'order.shopIdentifier');
         Assertion::uuid($object->getCurrencyIdentifier(), null, 'order.currencyIdentifier');
         Assertion::uuid($object->getPaymentMethodIdentifier(), null, 'order.paymentMethodIdentifier');
         Assertion::uuid($object->getOrderIdentifer(), null, 'order.orderIdentifier');


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| BC breaks?                | yes
| Deprecations?             | no
| Changelog updated?        | yes
| Tests exists and pass?    | yes
| License                   | MIT


#### What's in this PR?

added a check to only transfer product or orders when at least one of the shops has a mapped shop on the other adapter


#### Why?

products will not be imported if the shop is not mapped, but their images will be transported. This will lead to a excessive amount of data transfered.