### PR TITLE
fix price for markup calculation

### DIFF
--- a/Components/Import/PlentymarketsImportItemVariantController.php
+++ b/Components/Import/PlentymarketsImportItemVariantController.php
@@ -104,6 +104,8 @@ class PlentymarketsImportItemVariantController
         $this->purchasePrices = [];
 
         $this->ItemBase = $ItemBase;
+	    
+	$priceForMarkup = $this->getItemPrice($this->ItemBase->PriceSet);
 
         foreach ($this->ItemBase->ItemAttributeMarkup->item as $ItemAttributeMarkup) {
             // May be percentage or flat rate surcharge
@@ -202,7 +204,7 @@ class PlentymarketsImportItemVariantController
 
                     if ($markup) {
                         if ($Attribute->MarkupPercental == 1) {
-                            $markup = $this->ItemBase->PriceSet->Price / 100 * $markup;
+                            $markup = $priceForMarkup / 100 * $markup;
                         }
 
                         $this->variant2markup[$AttributeValueSet->AttributeValueSetID] += $markup;
@@ -315,5 +317,25 @@ class PlentymarketsImportItemVariantController
     public function getGroups()
     {
         return array_values($this->groups);
+    }
+	
+    /**
+     * Returns the item price
+     *
+     * @return double
+     */
+    protected function getItemPrice($ItemPrices)
+    {
+        $usePrice = PlentymarketsConfig::getInstance()->getItemPriceImportActionID(IMPORT_ITEM_PRICE);
+
+        if($usePrice != 'Price')
+        {
+            if(!empty($ItemPrices->{$usePrice}))
+            {
+                return $ItemPrices->{$usePrice};
+            }
+        }
+
+        return $ItemPrices->Price;
     }
 }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue|Enhancement
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        | no
| Tests exists and pass?    | no
| Related tickets           | fixes #X, partially #Y, mentioned in #Z
| License                   | MIT


#### What's in this PR?
This PR fix the price for the markup calculation.


#### Why?
In the standard, the basic price of an item is used for the markup calculation, if the markup is a percental markup. If the configured import item price is not the basic price, the calculation set a wrong markup.
