### PR TITLE
missing use statement when handling address splitting errors

### DIFF
--- a/Adapter/PlentymarketsAdapter/RequestGenerator/Order/Address/AddressRequestGenerator.php
+++ b/Adapter/PlentymarketsAdapter/RequestGenerator/Order/Address/AddressRequestGenerator.php
@@ -2,6 +2,7 @@
 
 namespace PlentymarketsAdapter\RequestGenerator\Order\Address;
 
+use Exception;
 use PlentyConnector\Connector\IdentityService\IdentityServiceInterface;
 use PlentyConnector\Connector\TransferObject\Country\Country;
 use PlentyConnector\Connector\TransferObject\Order\Address\Address;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- error handling when parsing order addresses
 
 ### Changed
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        | yes
| Tests exists and pass?    | no
| License                   | MIT


#### What's in this PR?
added a missing use statement


#### Why?
mybe optimizes the address splitting to behave better with missing house numbers