### PR TITLE
Fix duplicate PayPal payment transferral to plenty

### DIFF
--- a/Adapter/PlentymarketsAdapter/ServiceBus/CommandHandler/Payment/HandlePaymentCommandHandler.php
+++ b/Adapter/PlentymarketsAdapter/ServiceBus/CommandHandler/Payment/HandlePaymentCommandHandler.php
@@ -106,7 +106,7 @@ class HandlePaymentCommandHandler implements CommandHandlerInterface
 
         $paymentResult = $this->findOrCreatePlentyPayment($payment);
 
-        if ($orderIdentity->getAdapterIdentifier() == $paymentResult['order']['id']) {
+        if ($orderIdentity->getAdapterIdentifier() == $paymentResult['order']['orderId']) {
             return true;
         }
         $this->client->request(
@@ -127,7 +127,7 @@ class HandlePaymentCommandHandler implements CommandHandlerInterface
         $plentyPayments = $this->fetchPlentyPayments($payment->getTransactionReference());
         $paymentResult = $plentyPayments[0];
         if ($plentyPayments) {
-            $this->logger->notice('payment with the same transaction id "' . $plentyPayments['id'] . '" already exists.');
+            $this->logger->debug('payment with the same transaction id "' . $paymentResult['id'] . '" already exists.');
         } else {
             $paymentResult = $this->createPlentyPayment($payment);
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- don't transfer payment to plenty when payment with same transaction id exists
 - error handling when parsing order addresses
 - Bundle stock fix (@marcmanusch)
 - use correct tax when transferring order to plenty

--- a/Documentation/ErrorHandling.md
+++ b/Documentation/ErrorHandling.md
@@ -3,7 +3,7 @@ This Document should give a brief overview how and where the connector handels e
 
 
 ## Reading Phase
-During the reading phase of the connector, errors with different levels could potentially occour. 
+During the reading phase of the connector, errors with different levels could occur. 
 
 ### Exceptions / Warnings
 The corresponding object can not be processed.
@@ -13,11 +13,11 @@ The corresponding object will be processed, but the data in question will be ski
 
 ### No Message
 Some Settings could lead to an exclusion of an object. These conditions will not be logged as they are part of
-the adapter domain
+the adapter domain.
 
 
-## Persiting Phase
-During the write phase errors can also occour, but will be kept at a bare minimum.
+## Persisting Phase
+Errors can also occur during the write phase. Throwing exceptions will be avoided at all cost.
 
 ### Exceptions / Warnings
 The corresponding object can not be processed.


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        |yes
| License                   | MIT


#### What's in this PR?

Payments are not transferred to plenty, when a payment with the same transaction id exists.

#### Why?

In some cases when a PayPal payment is already captured in plenty and the payment transferral from shopware is delayed a second payment will be added to the order in plenty.



