### PR TITLE
Fixed \ShopwareAdapter\ResponseParser\GetAttributeTrait::getAttribute…

### DIFF
--- a/Adapter/ShopwareAdapter/ResponseParser/GetAttributeTrait.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/GetAttributeTrait.php
@@ -23,9 +23,15 @@ trait GetAttributeTrait
                 continue;
             }
 
+            if ($value instanceof \DateTime) {
+                $strValue = $value->format('Y-m-d H:i:s');
+            } else {
+                $strValue = (string) $value;
+            }
+
             $attribute = new Attribute();
             $attribute->setKey((string) $key);
-            $attribute->setValue((string) $value);
+            $attribute->setValue($strValue);
 
             $attributes[] = $attribute;
         }

--- a/Adapter/ShopwareAdapter/ResponseParser/GetAttributeTrait.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/GetAttributeTrait.php
@@ -2,6 +2,7 @@
 
 namespace ShopwareAdapter\ResponseParser;
 
+use DateTimeInterface;
 use PlentyConnector\Connector\ValueObject\Attribute\Attribute;
 
 /**
@@ -23,7 +24,7 @@ trait GetAttributeTrait
                 continue;
             }
 
-            if ($value instanceof \DateTime) {
+            if ($value instanceof DateTimeInterface) {
                 $strValue = $value->format('Y-m-d H:i:s');
             } else {
                 $strValue = (string) $value;


### PR DESCRIPTION
…s for $value being of type \DateTime by using the format method

| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        | no
| Tests exists and pass?    | no test case for this issue*
| Related tickets           | None that I know of
| License                   | MIT

* but tested with a real life work load and worked

#### What's in this PR?

This PR fixes \ShopwareAdapter\ResponseParser\GetAttributeTrait::getAttributes for cases in which $value is of type \DateTime. As this built-in PHP type does not have a __toString magic method the cast (string) $value will fatally fail.

This fix first checks if $value is an instance of \DateTime and if so, uses the format method to format the \DateTime value to a 'Y-m-d H:i:s' string representation and stores that string in a new variable $strValue.
If $value is not of that type it is still assumed that casting to string is safe and the result of that cast is stored in $strValue.
$strValue is now passed to setValue instead of $value.

#### Why?

Since it is perfectly acceptable for an attribute to be of type \DateTime this fix is necessary to ensure proper operation with real-life workloads.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

I leave that to the maintainers. :P

#### To Do

This PR in itself is probably complete enough but the maintainers should probably figure out if there are other similar cases in which a simple cast to string is not sufficient as well as write more exhaustive tests as a test class for this trait exists but it only covers the most trivial case. (No offense, I often do the same. :/)
