### PR TITLE
fix PriceResponseParser to prevent the import of pseudoprices that ar…

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Price/PriceResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Price/PriceResponseParser.php
@@ -285,7 +285,7 @@ class PriceResponseParser implements PriceResponseParserInterface
         }
 
         if (isset($priceArray['specialOffer'][$price->getFromAmount()])) {
-            $specialPrice = $priceArray['specialOffer'][$price->getFromAmount()];
+            $specialPrice = $priceArray['specialOffer'][$price->getFromAmount()]['price'];
 
             if (0.0 === $price->getPseudoPrice() && $specialPrice < $price->getPrice()) {
                 $price->setPseudoPrice($price->getPrice());

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Price/PriceResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Price/PriceResponseParser.php
@@ -285,7 +285,9 @@ class PriceResponseParser implements PriceResponseParserInterface
         }
 
         if (isset($priceArray['specialOffer'][$price->getFromAmount()])) {
-            if (0.0 === $price->getPseudoPrice()) {
+            $specialPrice = $priceArray['specialOffer'][$price->getFromAmount()];
+
+            if (0.0 === $price->getPseudoPrice() && $specialPrice < $price->getPrice()) {
                 $price->setPseudoPrice($price->getPrice());
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - import alternate media text as name if is set
 - import correct main translation
 - use correct item tax when transferring order to plenty
+- prevent the import of pseudoprices that are equal to the usual price 
 
 ### Changed
 - changed the sequence in which the definitions are processed, orders and payments are now fetched first.


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        | yes
| Tests exists and pass?    | no

#### What's in this PR?

This PR fixes the PriceResponseParser to prevent the import of pseudoprices that are equal to the usual price 

#### Why?

According to the old logic, it was possible to set a pseudo price equal to or even higher than the normal selling price.
For example, this causes the "has pseudoprice" filter to fail to work properly (because the product has a dummy price, but there is no discount)

#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

