### PR TITLE
add fallback for weight to VariantResponseParser

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -466,6 +466,6 @@ class VariationResponseParser implements VariationResponseParserInterface
             $weight = $variation['weightG'];
         }
 
-        return (float)($weight / 1000);
+        return (float) ($weight / 1000);
     }
 }

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -185,7 +185,7 @@ class VariationResponseParser implements VariationResponseParserInterface
             $variationObject->setWidth((int) $variation['widthMM']);
             $variationObject->setHeight((int) $variation['heightMM']);
             $variationObject->setLength((int) $variation['lengthMM']);
-            $variationObject->setWeight((float) ($variation['weightNetG'] / 1000));
+            $variationObject->setWeight($this->getVariationWeight($variation));
             $variationObject->setProperties($this->getVariationProperties($variation));
 
             $result[$variationObject->getIdentifier()] = $variationObject;
@@ -450,5 +450,22 @@ class VariationResponseParser implements VariationResponseParserInterface
         }
 
         return $translations;
+    }
+
+
+    /**
+     * @param array $variation
+     *
+     * @return float
+     */
+    private function getVariationWeight(array $variation)
+    {
+        if ($variation['weightNetG'] > 0) {
+            $weight = $variation['weightNetG'];
+        } else {
+            $weight = $variation['weightG'];
+        }
+
+        return (float)($weight / 1000);
     }
 }

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -452,7 +452,6 @@ class VariationResponseParser implements VariationResponseParserInterface
         return $translations;
     }
 
-
     /**
      * @param array $variation
      *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- fallback for the import of the weight (@jppeter)
 
 ### Fixed
 - prepareOrderItems validation fix 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| BC breaks?                | no|yes
| Deprecations?             | no|yes
| Changelog updated?        | yes


#### What's in this PR?

This PR adds a fallback for the weight-mapping inside the _VariationResponseParser_. If the variant has no _weightNetG_ given, it tries now to use _weightG_. 

#### Why?

Some customers are using only one of the weight columns

#### Checklist

- [X] Updated CHANGELOG.md


