### PR TITLE
Fix brutto netto order prices for 0 tax orders

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Order/OrderResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Order/OrderResponseParser.php
@@ -741,7 +741,6 @@ class OrderResponseParser implements OrderResponseParserInterface
             $orderItem->setName($item['orderItemName']);
             $orderItem->setNumber($number);
             $orderItem->setPrice($this->getOrderItemPrice($item));
-            $orderItem->setVatRateIdentifier($this->getVatRateIdentifier($entry));
             $orderItem->setAttributes([]);
 
             $result[] = $orderItem;
@@ -764,16 +763,6 @@ class OrderResponseParser implements OrderResponseParserInterface
         }
 
         return $price;
-    }
-
-    /**
-     * @param array $item
-     *
-     * @return string
-     */
-    private function getVatRateIdentifier(array $item)
-    {
-        return null;
     }
 
     /**

--- a/Adapter/PlentymarketsAdapter/ServiceBus/CommandHandler/Order/HandleOrderCommandHandler.php
+++ b/Adapter/PlentymarketsAdapter/ServiceBus/CommandHandler/Order/HandleOrderCommandHandler.php
@@ -34,7 +34,7 @@ class HandleOrderCommandHandler implements CommandHandlerInterface
     /**
      * @var OrderRequestGeneratorInterface
      */
-    private $orderRequestGeneretor;
+    private $orderRequestGenerator;
 
     /**
      * HandleOrderCommandHandler constructor.
@@ -50,7 +50,7 @@ class HandleOrderCommandHandler implements CommandHandlerInterface
     ) {
         $this->client = $client;
         $this->identityService = $identityService;
-        $this->orderRequestGeneretor = $orderRequestGeneretor;
+        $this->orderRequestGenerator = $orderRequestGeneretor;
     }
 
     /**
@@ -108,7 +108,7 @@ class HandleOrderCommandHandler implements CommandHandlerInterface
      */
     private function handleOrder(Order $order)
     {
-        $params = $this->orderRequestGeneretor->generate($order);
+        $params = $this->orderRequestGenerator->generate($order);
         $result = $this->client->request('post', 'orders', $params);
 
         $this->identityService->create(

--- a/Adapter/ShopwareAdapter/DependencyInjection/services.xml
+++ b/Adapter/ShopwareAdapter/DependencyInjection/services.xml
@@ -3,8 +3,12 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Misc Components -->
+        <service id="shopware_adapter.shopware_translation_component" class="Shopware_Components_Translation"/>
 
-        <service id="shopware_adapter.shopware_translation_component" class="Shopware_Components_Translation" />
+        <service id="shopware.tax_repository" class="Shopware\Models\Tax\Repository">
+            <factory service="models" method="getRepository"/>
+            <argument type="string">Shopware\Models\Tax\Tax</argument>
+        </service>
 
         <!-- Data Provider -->
 
@@ -109,6 +113,7 @@
 
         <service id="shopware_adapter.response_parser.order_item" class="ShopwareAdapter\ResponseParser\OrderItem\OrderItemResponseParser">
             <argument type="service" id="plenty_connector.identity_service" />
+            <argument type="service" id="shopware.tax_repository" />
         </service>
 
         <service id="shopware_adapter.response_parser.order_status" class="ShopwareAdapter\ResponseParser\OrderStatus\OrderStatusResponseParser">

--- a/Adapter/ShopwareAdapter/DependencyInjection/services.xml
+++ b/Adapter/ShopwareAdapter/DependencyInjection/services.xml
@@ -109,6 +109,7 @@
             <argument type="service" id="shopware_adapter.response_parser.customer" />
             <argument type="service" id="shopware_adapter.data_provider.currency" />
             <argument type="service" id="plenty_connector.logger" />
+            <argument type="service" id="shopware.tax_repository" />
         </service>
 
         <service id="shopware_adapter.response_parser.order_item" class="ShopwareAdapter\ResponseParser\OrderItem\OrderItemResponseParser">

--- a/Adapter/ShopwareAdapter/ResponseParser/Order/OrderResponseParser.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/Order/OrderResponseParser.php
@@ -77,14 +77,14 @@ class OrderResponseParser implements OrderResponseParserInterface
     /**
      * OrderResponseParser constructor.
      *
-     * @param IdentityServiceInterface $identityService
-     * @param EntityManagerInterface $entityManager
+     * @param IdentityServiceInterface         $identityService
+     * @param EntityManagerInterface           $entityManager
      * @param OrderItemResponseParserInterface $orderItemResponseParser
-     * @param AddressResponseParserInterface $orderAddressParser
-     * @param CustomerResponseParserInterface $customerParser
-     * @param CurrencyDataProviderInterface $currencyDataProvider
-     * @param LoggerInterface $logger
-     * @param EntityRepository $taxRepository
+     * @param AddressResponseParserInterface   $orderAddressParser
+     * @param CustomerResponseParserInterface  $customerParser
+     * @param CurrencyDataProviderInterface    $currencyDataProvider
+     * @param LoggerInterface                  $logger
+     * @param EntityRepository                 $taxRepository
      */
     public function __construct(
         IdentityServiceInterface $identityService,
@@ -261,7 +261,7 @@ class OrderResponseParser implements OrderResponseParserInterface
     }
 
     /**
-     * @param int $entry
+     * @param int    $entry
      * @param string $type
      *
      * @return string
@@ -312,7 +312,7 @@ class OrderResponseParser implements OrderResponseParserInterface
 
     /**
      * @param array $entry
-     * @param bool $taxFree
+     * @param bool  $taxFree
      *
      * @return OrderItem
      */

--- a/Adapter/ShopwareAdapter/ResponseParser/Order/OrderResponseParser.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/Order/OrderResponseParser.php
@@ -352,10 +352,10 @@ class OrderResponseParser implements OrderResponseParserInterface
     private function getShippingAmount(array $entry, $taxFree)
     {
         return $taxFree ?
-            $entry['shippingAmountNet'] + (
-                ($entry['shippingAmountNet'] / 100) *
+            $entry['invoiceShippingNet'] + (
+                ($entry['invoiceShippingNet'] / 100) *
                 $this->getMaxTaxRateFromOrderItems($entry)
             ) :
-            (float) $entry['shippingAmount'];
+            (float) $entry['invoiceShipping'];
     }
 }

--- a/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParser.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParser.php
@@ -36,7 +36,7 @@ class OrderItemResponseParser implements OrderItemResponseParserInterface
      * OrderItemResponseParser constructor.
      *
      * @param IdentityServiceInterface $identityService
-     * @param EntityRepository $taxRepository
+     * @param EntityRepository         $taxRepository
      */
     public function __construct(IdentityServiceInterface $identityService, EntityRepository $taxRepository)
     {

--- a/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParser.php
+++ b/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParser.php
@@ -54,7 +54,7 @@ class OrderItemResponseParser implements OrderItemResponseParserInterface
          */
         $orderItem = OrderItem::fromArray([
             'type' => $this->getItemType($entry['mode']),
-            'quantity' => (float)$entry['quantity'],
+            'quantity' => (float) $entry['quantity'],
             'name' => $entry['articleName'],
             'number' => $entry['articleNumber'],
             'price' => $this->getPrice($entry, $taxFree),
@@ -86,10 +86,9 @@ class OrderItemResponseParser implements OrderItemResponseParserInterface
         $entry['taxId'] = $taxModel->getId();
 
         $vatRateIdentity = $this->identityService->findOneBy([
-            'adapterIdentifier' => (string)$entry['taxId'],
+            'adapterIdentifier' => (string) $entry['taxId'],
             'adapterName' => ShopwareAdapter::NAME,
             'objectType' => VatRate::TYPE,
-
         ]);
 
         if (null === $vatRateIdentity) {
@@ -121,11 +120,12 @@ class OrderItemResponseParser implements OrderItemResponseParserInterface
     /**
      * @param array $entry
      * @param $taxFree
+     *
      * @return float|int|mixed
      */
     private function getPrice(array $entry, $taxFree)
     {
         return $taxFree ? $entry['price'] + (($entry['price'] / 100) * $entry['taxRate']) :
-            (float)$entry['price'];
+            (float) $entry['price'];
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fallback for the import of the weight (@jppeter)
 
 ### Fixed
+- fix tax calculation issue for third country zero tax orders
 - prepareOrderItems validation fix 
 - only transfer variations with valid clientid
 - import alternate media text as name if is set

--- a/Connector/TransferObject/Order/OrderItem/OrderItem.php
+++ b/Connector/TransferObject/Order/OrderItem/OrderItem.php
@@ -138,7 +138,6 @@ class OrderItem extends AbstractValueObject implements AttributableInterface
     /**
      * @param float $price
      */
-
     public function setPrice($price)
     {
         $this->price = $price;

--- a/Connector/TransferObject/Order/OrderItem/OrderItem.php
+++ b/Connector/TransferObject/Order/OrderItem/OrderItem.php
@@ -138,6 +138,7 @@ class OrderItem extends AbstractValueObject implements AttributableInterface
     /**
      * @param float $price
      */
+
     public function setPrice($price)
     {
         $this->price = $price;

--- a/tests/Unit/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParserTest.php
+++ b/tests/Unit/Adapter/ShopwareAdapter/ResponseParser/OrderItem/OrderItemResponseParserTest.php
@@ -5,6 +5,7 @@ namespace PlentyConnector\tests\Unit\Adapter\ShopwareAdapter\ResponseParser\Orde
 use PlentyConnector\Connector\TransferObject\Order\OrderItem\OrderItem;
 use PlentyConnector\Connector\ValueObject\Attribute\Attribute;
 use PlentyConnector\tests\Unit\Adapter\ShopwareAdapter\ResponseParser\ResponseParserTest;
+use Shopware\Models\Tax\Tax;
 use ShopwareAdapter\ResponseParser\OrderItem\OrderItemResponseParser;
 
 /**
@@ -23,8 +24,9 @@ class OrderItemResponseParserTest extends ResponseParserTest
     {
         parent::setUp();
 
-        $this->responseParser = $parser = new OrderItemResponseParser(
-            $this->identityService
+        $this->responseParser = new OrderItemResponseParser(
+            $this->identityService,
+            Shopware()->Models()->getRepository(Tax::class)
         );
     }
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| BC breaks?                | no
| Deprecations?             | no
| Changelog updated?        |yes
| Tests exists and pass?    |no
| Related tickets           | related #125
| License                   | MIT


#### What's in this PR?

All order item prices are passed as brutto prices according to the default tax rate of the tax rule (e.g. full tax rate -> 19% for orders with german tax).

#### Why?

For third country orders e.g. from Swiss with the full tax rate prices were calculated wrongly in plentymarkets.