### PR TITLE
Logging fix Name  -> Id attribute

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Image/ImageResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Image/ImageResponseParser.php
@@ -108,7 +108,7 @@ class ImageResponseParser implements ImageResponseParserInterface
             return $image;
         } catch (Exception $exception) {
             $this->logger->notice('error when parsing product image', [
-                'name' => $entry['name'],
+                'id' => $entry['id'],
                 'url' => $entry['url'],
             ]);
         }


### PR DESCRIPTION
Id ist more relevant - name identifies not deterministic the image, when error occurs.

| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

Doesn't make sence to get $entry['name'] - in the method is logic for getting the name and this attribute is not pressent in $entry => triggers: 
`PHP Notice:  Undefined index: name`

