### PR TITLE
Fix variation laststock

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -193,12 +193,12 @@ class ProductResponseParser implements ProductResponseParserInterface
     private function getStockLimitation(array $product)
     {
         foreach ($product['variations'] as $variation) {
-            if ($variation['stockLimitation']) {
-                return true;
+            if (!$variation['stockLimitation']) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -143,6 +143,7 @@ class VariationResponseParser implements VariationResponseParserInterface
             $variationObject->setActive((bool) $variation['isActive']);
             $variationObject->setIsMain($first);
             $variationObject->setNumber($this->getVariationNumber($variation));
+            $variationObject->setStockLimitation($this->getStockLimitation($variation));
             $variationObject->setBarcodes($this->getBarcodes($variation));
             $variationObject->setPosition((int) $variation['position']);
             $variationObject->setModel((string) $variation['model']);
@@ -451,5 +452,19 @@ class VariationResponseParser implements VariationResponseParserInterface
         }
 
         return (float) ($weight / 1000);
+    }
+
+    /**
+     * @param array $variation
+     *
+     * @return bool
+     */
+    private function getStockLimitation(array $variation)
+    {
+        if ($variation['stockLimitation']) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Adapter/ShopwareAdapter/RequestGenerator/Product/Variation/VariationRequestGenerator.php
+++ b/Adapter/ShopwareAdapter/RequestGenerator/Product/Variation/VariationRequestGenerator.php
@@ -67,6 +67,7 @@ class VariationRequestGenerator implements VariationRequestGeneratorInterface
             'active' => $variation->getActive(),
             'kind' => $variation->isMain() ? 1 : 2,
             'isMain' => $variation->isMain(),
+            'lastStock' => $variation->hasStockLimitation(),
             'standard' => $variation->isMain(),
             'shippingtime' => $variation->getShippingTime(),
             'prices' => $this->getPrices($variation),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [## [unreleased]]
 ### Fixed
 - transfer payment information without a real transactionid if needed
+- fix last stock for variations (sw >= 5.4.x)
 
 ### Changed
 

--- a/Connector/TransferObject/Product/Variation/Variation.php
+++ b/Connector/TransferObject/Product/Variation/Variation.php
@@ -93,6 +93,11 @@ class Variation extends AbstractTransferObject implements AttributableInterface
     private $referenceAmount = 0.0;
 
     /**
+     * @var bool
+     */
+    private $stockLimitation = false;
+
+    /**
      * @var float
      */
     private $maximumOrderQuantity;
@@ -393,6 +398,22 @@ class Variation extends AbstractTransferObject implements AttributableInterface
     public function setReferenceAmount($referenceAmount)
     {
         $this->referenceAmount = $referenceAmount;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasStockLimitation()
+    {
+        return $this->stockLimitation;
+    }
+
+    /**
+     * @param bool $stockLimitation
+     */
+    public function setStockLimitation($stockLimitation)
+    {
+        $this->stockLimitation = $stockLimitation;
     }
 
     /**


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

This PR fix the last stock settings for variations and set only the flag on the product, if all variations have set the flag in plentymarkets.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix