### PR TITLE
Removes necessity for an account holder for sepa payments

### DIFF
--- a/Components/Sepa/Shopware/SepaPaymentResponseParser.php
+++ b/Components/Sepa/Shopware/SepaPaymentResponseParser.php
@@ -143,10 +143,6 @@ class SepaPaymentResponseParser implements PaymentResponseParserInterface
 
         $paymentInstance = array_shift($element['paymentInstances']);
 
-        if (empty($paymentInstance['accountHolder'])) {
-            return false;
-        }
-
         if (empty($paymentInstance['iban'])) {
             return false;
         }


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

SEPA payments are only transferred to plentymarkets if an account holder is present in the payment instance. Shopware does not ask for an account holder for SEPA payments by default, so all the SEPA payments are blocked from transfer. This PR removes that necessity for an account holder.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix