### PR TITLE
fix main variation relation ship of an product

### DIFF
--- a/Adapter/PlentymarketsAdapter/DependencyInjection/services.xml
+++ b/Adapter/PlentymarketsAdapter/DependencyInjection/services.xml
@@ -84,6 +84,7 @@
         <service id="plentymarkets_adapter.helper.variation" class="PlentymarketsAdapter\Helper\VariationHelper">
             <argument type="service" id="plenty_connector.identity_service" />
             <argument type="service" id="plenty_connector.logger" />
+			<argument type="service" id="plenty_connector.config_service" />
         </service>
 
         <!-- Request Generator -->
@@ -224,6 +225,7 @@
             <argument type="service" id="plentymarkets_adapter.read_api.item.attribute" />
             <argument type="service" id="plentymarkets_adapter.read_api.item.barcode" />
             <argument type="service" id="plentymarkets_adapter.helper.reference_amount_calculator" />
+			<argument type="service" id="plentymarkets_adapter.helper.variation" />
 
             <argument type="service" id="plenty_connector.config_service" />
         </service>

--- a/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
+++ b/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
@@ -137,11 +137,11 @@ class VariationHelper implements VariationHelperInterface
         $mainVariationNumber = false;
         $found = false;
 
+        $mainVariationNumber = (string) $mainVariation['id'];
+
         if ($this->configService->get('variation_number_field', 'number') === 'number') {
             $mainVariationNumber = (string) $mainVariation['number'];
         }
-
-        $mainVariationNumber = (string) $mainVariation['id'];
 
         foreach ($variations as $variation) {
             if ($variation->getNumber() === $mainVariationNumber) {

--- a/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
+++ b/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
@@ -163,6 +163,7 @@ class VariationHelper implements VariationHelperInterface
 
             return $mainVariationNumber;
         }
+
         foreach ($variations as $variation) {
             if ($variation->getActive()) {
                 return $variation->getNumber();

--- a/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
+++ b/Adapter/PlentymarketsAdapter/Helper/VariationHelper.php
@@ -4,6 +4,7 @@ namespace PlentymarketsAdapter\Helper;
 
 use PlentymarketsAdapter\PlentymarketsAdapter;
 use Psr\Log\LoggerInterface;
+use SystemConnector\ConfigService\ConfigServiceInterface;
 use SystemConnector\IdentityService\IdentityServiceInterface;
 use SystemConnector\TransferObject\Shop\Shop;
 
@@ -19,10 +20,19 @@ class VariationHelper implements VariationHelperInterface
      */
     private $logger;
 
-    public function __construct(IdentityServiceInterface $identityService, LoggerInterface $logger)
-    {
+    /**
+     * @var ConfigServiceInterface
+     */
+    private $configService;
+
+    public function __construct(
+        IdentityServiceInterface $identityService,
+        LoggerInterface $logger,
+        ConfigServiceInterface $configService
+    ) {
         $this->identityService = $identityService;
         $this->logger = $logger;
+        $this->configService = $configService;
     }
 
     /**
@@ -96,5 +106,71 @@ class VariationHelper implements VariationHelperInterface
         }
 
         return $clientIds;
+    }
+
+    /**
+     * @param array $variations
+     *
+     * @return array
+     */
+    public function getMainVariation(array $variations)
+    {
+        $mainVariation = array_filter($variations, function ($variation) {
+            return $variation['isMain'] === true;
+        });
+
+        if (empty($mainVariation)) {
+            return [];
+        }
+
+        return reset($mainVariation);
+    }
+
+    /**
+     * @param Variation[] $variations
+     * @param array       $mainVariation
+     *
+     * @return string
+     */
+    public function getMainVariationNumber(array $variations = [], array $mainVariation)
+    {
+        $mainVariationNumber = false;
+        $found = false;
+
+        if ($this->configService->get('variation_number_field', 'number') === 'number') {
+            $mainVariationNumber = (string) $mainVariation['number'];
+        }
+
+        $mainVariationNumber = (string) $mainVariation['id'];
+
+        foreach ($variations as $variation) {
+            if ($variation->getNumber() === $mainVariationNumber) {
+                $found = true;
+                break;
+            }
+        }
+
+        if ($found) {
+            $checkActiveMainVariation = json_decode($this->configService->get('check_active_main_variation'));
+
+            if (!$checkActiveMainVariation && !$mainVariation['isActive']) {
+                foreach ($variations as $variation) {
+                    if ($variation->getActive()) {
+                        return $variation->getNumber();
+                    }
+                }
+            }
+
+            return $mainVariationNumber;
+        }
+        foreach ($variations as $variation) {
+            if ($variation->getActive()) {
+                return $variation->getNumber();
+            }
+        }
+
+        $variation = reset($variations);
+
+        return $variation->getNumber();
     }
 }

--- a/Adapter/PlentymarketsAdapter/Helper/VariationHelperInterface.php
+++ b/Adapter/PlentymarketsAdapter/Helper/VariationHelperInterface.php
@@ -15,4 +15,19 @@ interface VariationHelperInterface
      * @return array
      */
     public function getMappedPlentyClientIds();
+
+    /**
+     * @param array $variations
+     *
+     * @return array
+     */
+    public function getMainVariation(array $variations);
+
+    /**
+     * @param Variation[] $variations
+     * @param array       $mainVariation
+     *
+     * @return string
+     */
+    public function getMainVariationNumber(array $variations = [], array $mainVariation);
 }

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -109,7 +109,7 @@ class ProductResponseParser implements ProductResponseParserInterface
             return [];
         }
 
-        $mainVariation = $this->getMainVariation($product['variations']);
+        $mainVariation = $this->variationHelper->getMainVariation($product['variations']);
 
         if (empty($mainVariation)) {
             return [];
@@ -139,7 +139,7 @@ class ProductResponseParser implements ProductResponseParserInterface
         $productObject->setIdentifier($identity->getObjectIdentifier());
         $productObject->setName((string) $product['texts'][0]['name1']);
         $productObject->setActive($this->getActive($variations, $mainVariation));
-        $productObject->setNumber($this->getProductNumber($variations));
+        $productObject->setNumber($this->variationHelper->getMainVariationNumber($variations, $mainVariation));
         $productObject->setBadges($this->getBadges($product));
         $productObject->setShopIdentifiers($this->variationHelper->getShopIdentifiers($mainVariation));
         $productObject->setManufacturerIdentifier($this->getManufacturerIdentifier($product));
@@ -203,24 +203,6 @@ class ProductResponseParser implements ProductResponseParserInterface
         }
 
         return true;
-    }
-
-    /**
-     * @param array $variations
-     *
-     * @return array
-     */
-    private function getMainVariation(array $variations)
-    {
-        $mainVariation = array_filter($variations, function ($variation) {
-            return $variation['isMain'] === true;
-        });
-
-        if (empty($mainVariation)) {
-            return [];
-        }
-
-        return reset($mainVariation);
     }
 
     /**
@@ -666,9 +648,9 @@ class ProductResponseParser implements ProductResponseParserInterface
      */
     private function getActive(array $variations, array $mainVariation)
     {
-        $checkInactiveMainVariation = json_decode($this->configService->get('check_active_main_variation'));
+        $checkActiveMainVariation = json_decode($this->configService->get('check_active_main_variation'));
 
-        if (!$checkInactiveMainVariation && !$mainVariation['isActive']) {
+        if ($checkActiveMainVariation && !$mainVariation['isActive']) {
             return false;
         }
 
@@ -695,18 +677,6 @@ class ProductResponseParser implements ProductResponseParserInterface
         }
 
         return $properties;
-    }
-
-    /**
-     * @param Variation[] $variations
-     *
-     * @return string
-     */
-    private function getProductNumber(array $variations = [])
-    {
-        $variation = reset($variations);
-
-        return $variation->getNumber();
     }
 
     /**

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -199,7 +199,7 @@ class VariationResponseParser implements VariationResponseParserInterface
         $mainVariationNumber = $this->variationHelper->getMainVariationNumber($variations, $mainVariation);
 
         foreach ($variations as &$variation) {
-            if ($variation->getNumber() == $mainVariationNumber) {
+            if ($variation->getNumber() === $mainVariationNumber) {
                 $variation->setIsMain(true);
 
                 $checkActiveMainVariation = json_decode($this->configService->get('check_active_main_variation'));

--- a/Adapter/ShopwareAdapter/ServiceBus/CommandHandler/Variation/HandleVariationCommandHandler.php
+++ b/Adapter/ShopwareAdapter/ServiceBus/CommandHandler/Variation/HandleVariationCommandHandler.php
@@ -2,6 +2,7 @@
 
 namespace ShopwareAdapter\ServiceBus\CommandHandler\Variation;
 
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Components\Api\Manager;
@@ -174,7 +175,11 @@ class HandleVariationCommandHandler implements CommandHandlerInterface
 
         $this->entityManager->getConnection()->update(
             's_articles',
-            ['main_detail_id' => $variationModel->getId()],
+            [
+                'main_detail_id' => $variationModel->getId(),
+                'active' => $variation->getActive(),
+                'changetime' => (new DateTime('now'))->format('Y-m-d H:i:s'),
+            ],
             ['id' => $variationModel->getArticle()->getId()]
         );
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - transfer payment information without a real transactionid if needed
 - fix last stock for variations (sw >= 5.4.x)
+- fix product main variation relation ship
 
 ### Changed
 - sepa payment informations are now transfered even without a account holder (@jkrzefski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - extracted all database operations in the IdentityService into a own storage class (@jochenmanz)
 - extracted all database operations in the ConfigService into a own storage class (@jochenmanz)
 - extracted all database operations in the BacklogService into a own storage class (@jochenmanz)
+- change product edit date time if the variation sync updates variations of an product
 
 ### Added
 - paypal unified plugin integration


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue+Enhancement
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

This PR has the following changes for the main variation relation ship:

1.) I found a issue, that allways the sync linked the first variation as main variation. If a product has more then one variation, but only one variation is active, the product is not displayed on the store. A inactive variation is the main variation, but if the main variation is not active, the product is not active in the store.
I fixed it in the following steps:
- if the config was set, that use the inactive main variation, the product will be inactive.
- if the config was not set, check the main variation is active, take the main variation in plenty as main variation in shopware, otherwise take the first active variation
- if the main variation in plenty is not a full variation with attributes, then take the variation which is active, otherwise take the first variation in the array

2.) If the variation sync change variation of an product, so change the edit datetime of the product and change the active status of the product.

3.) Add new methods to the variationHelper.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix