### PR TITLE
set variation stock directly on variation response parser

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Stock/StockResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Stock/StockResponseParser.php
@@ -105,6 +105,6 @@ class StockResponseParser implements StockResponseParserInterface
             $arrayStocks[] = $stock['netStock'];
         }
 
-        return (float) array_sum($arrayStocks);
+        return (int) array_sum($arrayStocks);
     }
 }

--- a/Adapter/ShopwareAdapter/RequestGenerator/Product/Variation/VariationRequestGenerator.php
+++ b/Adapter/ShopwareAdapter/RequestGenerator/Product/Variation/VariationRequestGenerator.php
@@ -68,6 +68,7 @@ class VariationRequestGenerator implements VariationRequestGeneratorInterface
             'kind' => $variation->isMain() ? 1 : 2,
             'isMain' => $variation->isMain(),
             'lastStock' => $variation->hasStockLimitation(),
+            'inStock' => $variation->getInStock(),
             'standard' => $variation->isMain(),
             'shippingtime' => $variation->getShippingTime(),
             'prices' => $this->getPrices($variation),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - extracted all database operations in the BacklogService into a own storage class (@jochenmanz)
 - change cronjob scheduler to run not parallel cronjobs to avoid errors (@lacodimizer)
 - change product edit date time if the variation sync updates variations of an product (@lacodimizer)
+- change variation handling to set the stock directly and not over a additionally stock transfer object handling to optimize the performance (@lacodimizer)
 
 ### Added
 - paypal unified plugin integration

--- a/Connector/TransferObject/Product/Stock/Stock.php
+++ b/Connector/TransferObject/Product/Stock/Stock.php
@@ -21,9 +21,9 @@ class Stock extends AbstractTransferObject
     private $variationIdentifier = '';
 
     /**
-     * @var float
+     * @var int
      */
-    private $stock = 0.0;
+    private $stock = 0;
 
     /**
      * {@inheritdoc}
@@ -66,7 +66,7 @@ class Stock extends AbstractTransferObject
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getStock()
     {
@@ -74,7 +74,7 @@ class Stock extends AbstractTransferObject
     }
 
     /**
-     * @param float $stock
+     * @param int $stock
      */
     public function setStock($stock)
     {

--- a/Connector/TransferObject/Product/Variation/Variation.php
+++ b/Connector/TransferObject/Product/Variation/Variation.php
@@ -98,6 +98,11 @@ class Variation extends AbstractTransferObject implements AttributableInterface
     private $stockLimitation = false;
 
     /**
+     * @var int
+     */
+    private $inStock = 0;
+
+    /**
      * @var float
      */
     private $maximumOrderQuantity;
@@ -414,6 +419,22 @@ class Variation extends AbstractTransferObject implements AttributableInterface
     public function setStockLimitation($stockLimitation)
     {
         $this->stockLimitation = $stockLimitation;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInStock()
+    {
+        return $this->inStock;
+    }
+
+    /**
+     * @param int $inStock
+     */
+    public function setInStock($inStock)
+    {
+        $this->inStock = $inStock;
     }
 
     /**

--- a/Connector/Validator/Product/Stock/StockValidator.php
+++ b/Connector/Validator/Product/Stock/StockValidator.php
@@ -23,6 +23,6 @@ class StockValidator implements ValidatorInterface
     {
         Assertion::uuid($object->getIdentifier(), null, 'product.variation.stock.identifier');
         Assertion::uuid($object->getVariationIdentifier(), null, 'product.variation.stock.variationIdentifier');
-        Assertion::float($object->getStock(), null, 'product.variation.stock.stock');
+        Assertion::integer($object->getStock(), null, 'product.variation.stock.stock');
     }
 }

--- a/Connector/Validator/Product/Variation/VariationValidator.php
+++ b/Connector/Validator/Product/Variation/VariationValidator.php
@@ -46,6 +46,7 @@ class VariationValidator implements ValidatorInterface
         Assertion::nullOrUuid($object->getUnitIdentifier(), null, 'product.variation.unitIdentifier');
         Assertion::float($object->getReferenceAmount(), null, 'product.variation.referenceAmount');
         Assertion::boolean($object->hasStockLimitation(), null, 'product.variation.stockLimitation');
+        Assertion::integer($object->getInStock(), null, 'product.variation.inStock');
         Assertion::float($object->getMaximumOrderQuantity(), null, 'product.variation.maximumOrderQuantity');
         Assertion::float($object->getMinimumOrderQuantity(), null, 'product.variation.minimumOrderQuantity');
         Assertion::float($object->getIntervalOrderQuantity(), null, 'product.variation.intervalOrderQuantity');


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

This PR set the stock of an variation directly on the variation response parser and set it in the shopware request generator. So this enhancement reduce the backlogs, because a transfer command for the variation stock is not needed on a product / variation sync.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix