### PR TITLE
fix stockLimitation for variations without stock management

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -148,7 +148,6 @@ class ProductResponseParser implements ProductResponseParserInterface
         $productObject->setShippingProfileIdentifiers($this->getShippingProfiles($product));
         $productObject->setImages($this->getImages($product, $product['texts'], $result));
         $productObject->setVatRateIdentifier($this->getVatRateIdentifier($mainVariation));
-        $productObject->setStockLimitation($this->getStockLimitation($product));
         $productObject->setDescription((string) $product['texts'][0]['shortDescription']);
         $productObject->setLongDescription((string) $product['texts'][0]['description']);
         $productObject->setMetaTitle((string) $product['texts'][0]['name1']);
@@ -187,22 +186,6 @@ class ProductResponseParser implements ProductResponseParserInterface
 
             return $object;
         }, $candidatesForProcessing);
-    }
-
-    /**
-     * @param array $product
-     *
-     * @return bool
-     */
-    private function getStockLimitation(array $product)
-    {
-        foreach ($product['variations'] as $variation) {
-            if (!$variation['stockLimitation']) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -491,7 +491,7 @@ class VariationResponseParser implements VariationResponseParserInterface
      */
     private function getStockLimitation(array $variation)
     {
-        if ($variation['stockLimitation']) {
+        if ($variation['stockLimitation'] == 1) {
             return true;
         }
 

--- a/Adapter/ShopwareAdapter/RequestGenerator/Product/ProductRequestGenerator.php
+++ b/Adapter/ShopwareAdapter/RequestGenerator/Product/ProductRequestGenerator.php
@@ -131,7 +131,6 @@ class ProductRequestGenerator implements ProductRequestGeneratorInterface
             'categories' => $this->getCategories($product),
             'seoCategories' => $this->getSeoCategories($product),
             'taxId' => $vatIdentity->getAdapterIdentifier(),
-            'lastStock' => $product->hasStockLimitation(),
             'notification' => $this->configService->get('item_notification') === 'true' ? 1 : 0,
             'active' => $product->isActive(),
             'highlight' => $this->getHighlightFlag($product),

--- a/Connector/TransferObject/Product/Product.php
+++ b/Connector/TransferObject/Product/Product.php
@@ -75,11 +75,6 @@ class Product extends AbstractTransferObject implements TranslateableInterface, 
     private $vatRateIdentifier = '';
 
     /**
-     * @var bool
-     */
-    private $stockLimitation = false;
-
-    /**
      * @var string
      */
     private $description = '';
@@ -336,22 +331,6 @@ class Product extends AbstractTransferObject implements TranslateableInterface, 
     public function setVatRateIdentifier($vatRateIdentifier)
     {
         $this->vatRateIdentifier = $vatRateIdentifier;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasStockLimitation()
-    {
-        return $this->stockLimitation;
-    }
-
-    /**
-     * @param bool $stockLimitation
-     */
-    public function setStockLimitation($stockLimitation)
-    {
-        $this->stockLimitation = $stockLimitation;
     }
 
     /**

--- a/Connector/Validator/Product/ProductValidator.php
+++ b/Connector/Validator/Product/ProductValidator.php
@@ -52,8 +52,6 @@ class ProductValidator implements ValidatorInterface
 
         Assertion::uuid($object->getVatRateIdentifier(), null, 'product.vatRateIdentifier');
 
-        Assertion::boolean($object->hasStockLimitation(), null, 'product.stockLimitation');
-
         Assertion::string($object->getDescription(), null, 'product.description');
         Assertion::string($object->getLongDescription(), null, 'product.longDescription');
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

This PR fix the stockLimitation variations without stock management in Plentymarkets and optimize the merged PR https://github.com/plentymarkets/plentymarkets-shopware-connector/pull/407.

The product flag stockLimitation is removed, because since 5.4, the column is deprecated. If the column is set, so Shopware will set this flag for all variations. A other issue is, when a variations has no stockLimitation but the product has the activated flag, Shopware will display an notice, when you add a variation without stockLimitation to the basket. In this case, we should open a issue on the Shopware issue tracker.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix