### PR TITLE
Retrieve properties linked to a variation

### DIFF
--- a/Adapter/PlentymarketsAdapter/ReadApi/Item/Variation.php
+++ b/Adapter/PlentymarketsAdapter/ReadApi/Item/Variation.php
@@ -19,7 +19,7 @@ class Variation extends ApiAbstract
         'variationBarcodes',
         'images',
         'stock',
-        'variationProperties',
+        'properties',
     ];
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fix product main variation relation ship (@lacodimizer)
 - fix product active state on variation sync(@lacodimizer)
 - fix variation sync with wrong product association like images (@lacodimizer)
+- retrieve variation properties
 
 ### Changed
 - sepa payment informations are now transfered even without a account holder (@jkrzefski)


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue|Enhancement
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

As said [here](https://forum.plentymarkets.com/t/varianteneigenschaften-variationproperties-falsche-werte/502168/14?u=sk_wesionaire), 'variationProperties' is just a legacy key which has been replaced by 'properties'. I know that we're not importing variation-properties at the moment due to Shopware's limitations. But we should change it anyways in order to offer plugins a way to use the variation properties. 
At least variationProperties should be removed from the API-Reader as it always returns an empty array.


#### Checklist

- [X] Updated CHANGELOG.md to describe the bugfix