### PR TITLE
fix category command handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-[## [unreleased]]
+## [## [unreleased]]
 ### Fixed
 - fix category sync if more then one shop has the same root category (@lacodimizer)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[## [unreleased]]
+### Fixed
+- fix category sync if more then one shop has the same root category (@lacodimizer)
+
 ## [## [5.1.0]]
 ### Fixed
 - transfer payment information without a real transactionid if needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [## [unreleased]]
+## [## [5.1.0]]
 ### Fixed
 - transfer payment information without a real transactionid if needed
 - fix last stock for variations (sw >= 5.4.x)

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     <label>plentymarkets Shopware Connector</label>
     <label lang="de">plentymarkets Shopware Connector</label>
 
-    <version>5.0.0</version>
+    <version>5.1.0</version>
     <copyright>(c) plentymarkets GmbH</copyright>
     <link>https://www.plentymarkets.eu/</link>
     <author>arvatis media GmbH</author>


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | yes
| License                   | MIT


#### What's in this PR?

This PR fix the category sync, if more then one shop has the same configured root category.
Actual, the category sync abort with the error "missing parent category".
The change of the command handler will check, if the matched category include the shopware shop root category and will check the attribute field "shopIdentifier" no more.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix