### PR TITLE
fix duplicate blacklog entries

### DIFF
--- a/DependencyInjection/definitions.xml
+++ b/DependencyInjection/definitions.xml
@@ -121,7 +121,7 @@
             <argument>%plenty_connector.adapter.plentymarkets%</argument>
             <argument>%plenty_connector.adapter.shopware%</argument>
             <argument>%plenty_connector.transfer_object.variation%</argument>
-            <argument>20</argument>
+            <argument>30</argument>
 
             <tag name="plenty_connector.connector_definition" />
             <tag name="plenty_connector.cleanup_definition" />


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

This PR fix duplicate backlog entries on plentyconnector:process.
If a product was updated, the variations will be updated during the sync too.
So there are 2 entries of the same object, only the prio is a other.

You can test it:
- Set the market timestamp on 1 product
- Start sync (plentyconnector:process)
=> remember the count of entries

After the changed prio, do it the same.
You will see the half count of entries.


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix