### PR TITLE
Add (parent) Article ID to free-text-fields

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -872,7 +872,7 @@ class ProductResponseParser implements ProductResponseParserInterface
     {
         $attribute = new Attribute();
         $attribute->setKey('articleId');
-        $attribute->setValue($product['id']);
+        $attribute->setValue((string) $product['id']);
 
         return $attribute;
     }

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -704,6 +704,7 @@ class ProductResponseParser implements ProductResponseParserInterface
         $attributes[] = $this->getAgeRestrictionAsAttribute($product);
         $attributes[] = $this->getSecondProductNameAsAttribute($product);
         $attributes[] = $this->getThirdProductNameAsAttribute($product);
+        $attributes[] = $this->getArticleId($product);
 
         return $attributes;
     }
@@ -858,6 +859,20 @@ class ProductResponseParser implements ProductResponseParserInterface
         $attribute = new Attribute();
         $attribute->setKey('ageRestriction');
         $attribute->setValue((string) $product['ageRestriction']);
+
+        return $attribute;
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return Attribute
+     */
+    private function getArticleId(array $product)
+    {
+        $attribute = new Attribute();
+        $attribute->setKey('articleId');
+        $attribute->setValue($product['id']);
 
         return $attribute;
     }

--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/ProductResponseParser.php
@@ -704,7 +704,7 @@ class ProductResponseParser implements ProductResponseParserInterface
         $attributes[] = $this->getAgeRestrictionAsAttribute($product);
         $attributes[] = $this->getSecondProductNameAsAttribute($product);
         $attributes[] = $this->getThirdProductNameAsAttribute($product);
-        $attributes[] = $this->getArticleId($product);
+        $attributes[] = $this->getItemIdAsAttribute($product);
 
         return $attributes;
     }
@@ -868,10 +868,10 @@ class ProductResponseParser implements ProductResponseParserInterface
      *
      * @return Attribute
      */
-    private function getArticleId(array $product)
+    private function getArticleIdAsAttribute(array $product)
     {
         $attribute = new Attribute();
-        $attribute->setKey('articleId');
+        $attribute->setKey('itemId');
         $attribute->setValue((string) $product['id']);
 
         return $attribute;


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | Enhancement
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

Since many Plentyshops use the Article ID (not Variant ID) in the SEO-URL it's nice to have the parent article ID in shopware (e.g. for SEO-Routing rules)


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix